### PR TITLE
model.py: add git_url

### DIFF
--- a/searxinstances/instances.yml
+++ b/searxinstances/instances.yml
@@ -56,6 +56,7 @@ https://search.snopyta.org:
 https://search.spaeth.me: {}
 https://search.st8.at: {}
 https://search.stinpriza.org:
+  git_url: https://salsa.debian.org/debian/searx
   additional_urls:
     http://z5vawdol25vrmorm4yydmohsd4u6rdoj2sylvoi3e3nqvxkvpqul7bqd.onion: Hidden Service
 https://search.trom.tf: {}

--- a/searxinstances/instances.yml
+++ b/searxinstances/instances.yml
@@ -173,7 +173,8 @@ https://seeks.hsbp.org:
 https://skyn3t.in/srx:
   additional_urls:
     http://skyn3tb3bas655mw.onion/srx: hidden service
-https://spot.ecloud.global: {}
+https://spot.ecloud.global:
+  git_url: https://gitlab.e.foundation/e/cloud/my-spot
 https://start.paulgo.io: {}
 https://suche.dasnetzundich.de:
   comments:

--- a/searxinstances/model.py
+++ b/searxinstances/model.py
@@ -61,14 +61,16 @@ class AdditionalUrlList(OrderedDict, yaml.YAMLObject):
 class Instance(yaml.YAMLObject):
 
     yaml_tag = '!Instance'
-    __slots__ = ['comments', 'additional_urls']
+    __slots__ = ['comments', 'additional_urls', 'git_url']
 
-    def __init__(self, comments=None, additional_urls=None):
+    def __init__(self, comments=None, additional_urls=None, git_url=None):
         # type check
         if not isinstance(comments, (list, NoneType)):
             raise ValueError('comments is not a list')
         if not isinstance(additional_urls, (AdditionalUrlList, NoneType)):
             raise ValueError('additional_urls is not a AdditionalUrlList instance')
+        if not isinstance(git_url, (str, NoneType)):
+            raise ValueError('git_url is not a str')
         if comments is None:
             comments = []
         if additional_urls is None:
@@ -76,11 +78,13 @@ class Instance(yaml.YAMLObject):
         # assign
         self.comments = comments
         self.additional_urls = additional_urls
+        self.git_url = git_url
 
     def to_json(self):
         return dict([
             ("comments", self.comments),
-            ("additional_urls", self.additional_urls)
+            ("additional_urls", self.additional_urls),
+            ("git_url", self.git_url),
         ])
 
     def __repr__(self):
@@ -89,6 +93,8 @@ class Instance(yaml.YAMLObject):
     @staticmethod
     def yaml_representer(dumper: yaml.Dumper, instance):
         output = []
+        if instance.git_url is not None:
+            output.append(('git_url', instance.git_url))
         if instance.comments is not None and len(instance.comments) > 0:
             output.append(('comments', instance.comments))
         if instance.additional_urls is not None and len(instance.additional_urls) > 0:


### PR DESCRIPTION
some instances don't update settings.yml/brand/git_url
Example
* The [searx debian package](https://salsa.debian.org/debian/searx/-/blob/master/searx/brand.py). Existing instance: https://search.stinpriza.org
* my-spot fork: https://gitlab.e.foundation/e/cloud/my-spot . So 

```yaml
https://spot.ecloud.global: {}
```
can be edited
```
https://spot.ecloud.global:
  git_url: https://gitlab.e.foundation/e/cloud/my-spot
```

so searx-stats2 gives a grade "Cjs" but it should be actually "F" (fork).
this new field allows to specify the git URL directly into instances.yml