### PR TITLE
Remove searx.decatec.de

### DIFF
--- a/searxinstances/instances.yml
+++ b/searxinstances/instances.yml
@@ -71,7 +71,6 @@ https://searx.bissisoft.com:
   additional_urls:
     http://zbuc3bbzbfdqqo2x46repx2ddajbha6fpsjeeptjhhhhzji3zopxdqyd.onion/: Hidden Service
 https://searx.ch: {}
-https://searx.decatec.de: {}
 https://searx.deepak.pro: {}
 https://searx.devol.it: {}
 https://searx.divided-by-zero.eu:


### PR DESCRIPTION
After being on the "official list" for quite some time, I want to keep the instance more private now.
So it should be removed from the list.